### PR TITLE
Ensure your App Service is accessible via HTTPS only

### DIFF
--- a/challenge1/terraform/main.tf
+++ b/challenge1/terraform/main.tf
@@ -30,7 +30,7 @@ resource "azurerm_app_service_plan" "main" {
 
 # Provision the Azure App Service to host the main web site
 resource "azurerm_app_service" "main" {
-    name                = "${var.prefix}-appservice"
+  name                = "${var.prefix}-appservice"
     location            = azurerm_resource_group.main.location
     resource_group_name = azurerm_resource_group.main.name
     app_service_plan_id = azurerm_app_service_plan.main.id
@@ -54,4 +54,5 @@ resource "azurerm_app_service" "main" {
         "Personalizer__ApiKey"          = ""
         "Personalizer__Endpoint"        = ""
     }
+  https_only = true
 }


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to configure your App Service to be accessible via HTTPS only. By default, both HTTP and HTTPS are available.

