### PR TITLE
Ensure your App Service is accessible via HTTPS only

### DIFF
--- a/challenge2/terraform/main.tf
+++ b/challenge2/terraform/main.tf
@@ -60,6 +60,7 @@ resource "azurerm_app_service" "main" {
     "Personalizer_ApiKey"         = ""
     "Personalizer_Endpoint"       = ""
   }
+  https_only = true
 }
 
 # resource "azurerm_app_service_source_control" "main" {


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to configure your App Service to be accessible via HTTPS only. By default, both HTTP and HTTPS are available.

