### PR TITLE
Ensure to enable the latest TLS/SSL policy for the load balancer

### DIFF
--- a/challenge2/terraform/main.tf
+++ b/challenge2/terraform/main.tf
@@ -87,6 +87,7 @@ resource "azurerm_storage_account" "main" {
   location                 = azurerm_resource_group.main.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version = "TLS1_2"
 }
 
 resource "azurerm_storage_share" "main" {


### PR DESCRIPTION
This pull request improves our infrastructure by fixing a security issue found by [Shisho Cloud](https://shisho.dev).

## Description from Shisho Cloud

It is better to enable the latest TLS/SSL policy for the load balancer. Three versions of the TLS protocol, 1.0, 1.1, and 1.2 are available at the moment. TLS 1.2 should be selected if you do not have special reasons.

